### PR TITLE
Fix appdata.xml which was failing to validate

### DIFF
--- a/com.endlessnetwork.tankwarriors.appdata.xml
+++ b/com.endlessnetwork.tankwarriors.appdata.xml
@@ -5,7 +5,7 @@
   <project_license>LicenseRef-proprietary</project_license>
   <developer_name>Endless Studios</developer_name>
   <summary>Driving, shooting, explosions, and programming - all in one game</summary>
-  <metadata_license>CC0-1.0.5</metadata_license>
+  <metadata_license>CC0-1.0</metadata_license>
   <launchable type="desktop-id">com.endlessnetwork.tankwarriors.desktop</launchable>
   <categories>
     <category>LearnToCode</category>
@@ -20,13 +20,13 @@
   </description>
   <screenshots>
     <screenshot>
-      <image type="source">https://github.com/endless-network/TankWarriors_Binary/raw/master/TW4.jpg</image>
+      <image type="source">https://github.com/endless-network/TankWarriors_Binary/raw/master/TW4.png</image>
     </screenshot>
     <screenshot>
-      <image type="source">https://github.com/endless-network/TankWarriors_Binary/raw/master/TW3.jpg</image>
+      <image type="source">https://github.com/endless-network/TankWarriors_Binary/raw/master/TW3.png</image>
     </screenshot>
     <screenshot>
-      <image type="source">https://github.com/endless-network/TankWarriors_Binary/raw/master/TW2.jpg</image>
+      <image type="source">https://github.com/endless-network/TankWarriors_Binary/raw/master/TW2.png</image>
     </screenshot>
     <screenshot>
       <image type="source">https://github.com/endless-network/TankWarriors_Binary/raw/master/TW1.jpg</image>


### PR DESCRIPTION
The following validator was failing...

    flatpak run org.freedesktop.appstream-glib validate com.endlessnetwork.tankwarriors.appdata.xml

With this output:

```
com.endlessnetwork.tankwarriors.appdata.xml: FAILED:
• tag-invalid           : <metadata_license> is not valid [CC0-1.0.5]
• url-not-found         : <screenshot> failed to download (HTTP 404: Not Found) [https://github.com/endless-network/TankWarriors_Binary/raw/master/TW4.jpg]
• url-not-found         : <screenshot> failed to download (HTTP 404: Not Found) [https://github.com/endless-network/TankWarriors_Binary/raw/master/TW3.jpg]
• url-not-found         : <screenshot> failed to download (HTTP 404: Not Found) [https://github.com/endless-network/TankWarriors_Binary/raw/master/TW2.jpg]
Validation of files failed
```
