### PR TITLE
Add Education category to metainfo

### DIFF
--- a/com.endlessnetwork.tankwarriors.appdata.xml
+++ b/com.endlessnetwork.tankwarriors.appdata.xml
@@ -10,6 +10,7 @@
   <categories>
     <category>LearnToCode</category>
     <category>Game</category>
+    <category>Education</category>
   </categories>
   <releases>
 		<release version="1.3" date="2019-05-01"/>


### PR DESCRIPTION
The listed `<categories>` have to be defined in the [freedesktop menu specification](https://specifications.freedesktop.org/menu-spec/latest/apas02.html). `LearnToCode` is not, which meant that outside of a forked Endless copy of gnome-software, the game wasn’t appearing in people’s app centres.

Fix that by adding categories which are defined in the specification. Keep `LearnToCode` for backwards compatibility with old versions of Endless gnome-software.